### PR TITLE
Fix cell output formatting to match Julia REPL behavior

### DIFF
--- a/src/runners.jl
+++ b/src/runners.jl
@@ -226,7 +226,23 @@ function interrupt!(runner::AsyncRunner)
 end
 
 function book_display(value)
-    return value
+    # Return nothing for void results (like assignments ending with semicolon)
+    if value === nothing
+        return nothing
+    end
+    
+    # For other values, format them like Julia REPL using text/plain MIME
+    # This provides proper array formatting with delimiters and type information
+    # Add trailing newline to match REPL behavior exactly
+    formatted = sprint(show, MIME"text/plain"(), value)
+    
+    # Wrap in DOM.pre to preserve whitespace and newlines in web display
+    # This ensures the formatted output displays exactly like in Julia REPL
+    # Use inherit to match the notebook's font system
+    return DOM.pre(
+        formatted * "\n", 
+        style = "margin: 0; font-family: inherit; white-space: pre;"
+    )
 end
 
 function run!(editor::EvalEditor)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,9 +12,13 @@ InlineBook(joinpath(path, "intro.md"), replace_style=true)
 InlineBook(joinpath(path, "sunny.ipynb"), replace_style=true)
 InlineBook(joinpath(path, "test.md"), replace_style=true)
 
-
 @test isfile(joinpath(path, "test.md"))
 @test isdir(joinpath(path, ".test-bbook"))
 @test isdir(joinpath(path, ".test-bbook", "data"))
+
+# Clean up
 rm(joinpath(path, "test.md"), force=true)
 rm(joinpath(path, ".test-bbook"), force=true, recursive=true)
+
+# Include detailed book_display function tests
+include("test_book_display.jl")

--- a/test/test_book_display.jl
+++ b/test/test_book_display.jl
@@ -1,0 +1,96 @@
+# Test file specifically for book_display function
+using Test
+using BonitoBook
+
+@testset "book_display Function Tests" begin
+    @testset "Basic Functionality" begin
+        # Test nothing handling
+        @test BonitoBook.book_display(nothing) === nothing
+        
+        # Test that non-nothing values return DOM.pre elements
+        result = BonitoBook.book_display(42)
+        @test result isa BonitoBook.Bonito.DOM.Node
+        @test result.tag == "pre"
+    end
+    
+    @testset "Array Formatting" begin
+        # Simple array
+        arr = [1, 2, 3, 4, 5]
+        result = BonitoBook.book_display(arr)
+        @test result isa BonitoBook.Bonito.DOM.Node
+        @test result.tag == "pre"
+        
+        # Check that the content includes REPL-style formatting
+        content = string(result.children[1])
+        @test occursin("5-element Vector{Int64}:", content)
+        @test occursin(" 1", content)  # Check proper spacing
+        @test occursin(" 2", content)
+        
+        # Nested array
+        nested = [[1, 2], [3, 4]]
+        nested_result = BonitoBook.book_display(nested)
+        nested_content = string(nested_result.children[1])
+        @test occursin("2-element Vector{Vector{Int64}}:", nested_content)
+        
+        # String array
+        strings = ["hello", "world"]
+        string_result = BonitoBook.book_display(strings)
+        string_content = string(string_result.children[1])
+        @test occursin("2-element Vector{String}:", string_content)
+        @test occursin("\"hello\"", string_content)
+        @test occursin("\"world\"", string_content)
+    end
+    
+    @testset "Matrix Formatting" begin
+        # Matrix
+        matrix = [1 2 3; 4 5 6]
+        result = BonitoBook.book_display(matrix)
+        content = string(result.children[1])
+        @test occursin("2×3 Matrix{Int64}:", content)
+        @test occursin("1  2  3", content)
+        @test occursin("4  5  6", content)
+    end
+    
+    @testset "Special Types" begin
+        # Complex numbers
+        complex_arr = [1+2im, 3+4im]
+        result = BonitoBook.book_display(complex_arr)
+        content = string(result.children[1])
+        @test occursin("Complex{Int64}", content)
+        @test occursin("1 + 2im", content)
+        
+        # Boolean array
+        bool_arr = [true, false, true]
+        result = BonitoBook.book_display(bool_arr)
+        content = string(result.children[1])
+        @test occursin("3-element Vector{Bool}:", content)
+        
+        # Empty array
+        empty_arr = Int64[]
+        result = BonitoBook.book_display(empty_arr)
+        content = string(result.children[1])
+        @test occursin("0-element Vector{Int64}", content)
+    end
+    
+    @testset "CSS Styling" begin
+        # Check that the DOM.pre element has proper styling
+        result = BonitoBook.book_display([1, 2, 3])
+        @test haskey(result.attributes, :style)
+        style = result.attributes[:style]
+        @test occursin("white-space: pre", style)
+        @test occursin("font-family: inherit", style)
+        @test occursin("margin: 0", style)
+    end
+    
+    @testset "Trailing Newline" begin
+        # Check that trailing newline is added
+        result = BonitoBook.book_display(42)
+        content = string(result.children[1])
+        @test endswith(content, "\n")
+        
+        # Check array also has trailing newline
+        arr_result = BonitoBook.book_display([1, 2, 3])
+        arr_content = string(arr_result.children[1])
+        @test endswith(arr_content, "\n")
+    end
+end


### PR DESCRIPTION
Simple fix to issue reported in https://discourse.julialang.org/t/ann-bonitobook-jl/131442/7?u=hz-xiaxz

Now it aligns the Julia REPL behavior
<img width="1674" height="666" alt="image" src="https://github.com/user-attachments/assets/dbff6d91-e87d-4c9e-bde7-2f1fd86c9039" />


Some TODO (maybe seperate PR?)
- [ ] truncate long outputs
- [ ] LaTeX fonts compat
- [ ] Different font choice for outputs?
<img width="1668" height="294" alt="image" src="https://github.com/user-attachments/assets/6e14a55c-10a9-40aa-8e4a-57a02899e47a" />
